### PR TITLE
Improve analysis incomplete error handling

### DIFF
--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -1,6 +1,5 @@
 import concurrent.futures
 import hashlib
-import json
 import logging
 import multiprocessing
 import threading
@@ -49,6 +48,63 @@ class ProgramInfo:
             and self.collection is not None
             and self.strings_collection is not None
         )
+
+
+class AnalysisIncompleteError(RuntimeError):
+    """Raised when a tool is invoked before binary analysis has completed."""
+
+    def __init__(
+        self,
+        *,
+        binary_name: str,
+        ghidra_analysis_complete: bool,
+        code_collection_ready: bool,
+        strings_collection_ready: bool,
+        suggestion: str = "Wait and try tool call again.",
+    ) -> None:
+        self.binary_name = binary_name
+        self.ghidra_analysis_complete = ghidra_analysis_complete
+        self.code_collection_ready = code_collection_ready
+        self.strings_collection_ready = strings_collection_ready
+        self.suggestion = suggestion
+
+        message = self._build_message()
+        super().__init__(message)
+
+    def _build_message(self) -> str:
+        pending = self.pending_components
+        pending_message = (
+            f" Pending components: {', '.join(pending)}." if pending else ""
+        )
+        return (
+            f"Analysis incomplete for binary '{self.binary_name}'."
+            f"{pending_message} {self.suggestion}"
+        ).strip()
+
+    @property
+    def pending_components(self) -> list[str]:
+        """Return a list describing which analysis steps are unfinished."""
+
+        components: list[str] = []
+        if not self.ghidra_analysis_complete:
+            components.append("Ghidra analysis")
+        if not self.code_collection_ready:
+            components.append("code semantic index")
+        if not self.strings_collection_ready:
+            components.append("string semantic index")
+        return components
+
+    def to_dict(self) -> dict[str, Any]:
+        """Structured details describing the incomplete analysis state."""
+
+        return {
+            "binary_name": self.binary_name,
+            "ghidra_analysis_complete": self.ghidra_analysis_complete,
+            "code_collection_ready": self.code_collection_ready,
+            "strings_collection_ready": self.strings_collection_ready,
+            "pending_components": self.pending_components,
+            "suggestion": self.suggestion,
+        }
 
 
 class PyGhidraContext:
@@ -230,17 +286,11 @@ class PyGhidraContext:
                 f"Binary {binary_name} not found. Available binaries: {available_progs}"
             )
         if not program_info.analysis_complete:
-            raise RuntimeError(
-                json.dumps(
-                    {
-                        "message": f"Analysis incomplete for binary '{binary_name}'.",
-                        "binary_name": binary_name,
-                        "ghidra_analysis_complete": program_info.ghidra_analysis_complete,
-                        "code_collection": program_info.collection,
-                        "strings_collection": program_info.strings_collection,
-                        "suggestion": "Wait and try tool call again.",
-                    }
-                )
+            raise AnalysisIncompleteError(
+                binary_name=binary_name,
+                ghidra_analysis_complete=program_info.ghidra_analysis_complete,
+                code_collection_ready=program_info.collection is not None,
+                strings_collection_ready=program_info.strings_collection is not None,
             )
         return program_info
 

--- a/tests/unit/test_analysis_incomplete_error.py
+++ b/tests/unit/test_analysis_incomplete_error.py
@@ -1,0 +1,121 @@
+import sys
+import types
+
+import pytest
+
+
+def _ensure_stubbed_dependency(module_name: str, module: types.ModuleType) -> None:
+    if module_name not in sys.modules:
+        sys.modules[module_name] = module
+
+
+if "chromadb" not in sys.modules:
+    chromadb_module = types.ModuleType("chromadb")
+    chromadb_module.__path__ = []  # mark as package for submodule imports
+
+    class _StubCollection:  # pragma: no cover - simple placeholder
+        pass
+
+    class _StubPersistentClient:  # pragma: no cover - simple placeholder
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+        def get_collection(self, *args, **kwargs):  # pragma: no cover - placeholder
+            raise RuntimeError("stub client does not provide collections")
+
+    chromadb_module.Collection = _StubCollection
+    chromadb_module.PersistentClient = _StubPersistentClient
+    _ensure_stubbed_dependency("chromadb", chromadb_module)
+
+    chromadb_config_module = types.ModuleType("chromadb.config")
+
+    class _StubSettings:  # pragma: no cover - simple placeholder
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+
+    chromadb_config_module.Settings = _StubSettings
+    _ensure_stubbed_dependency("chromadb.config", chromadb_config_module)
+
+
+if "pyghidra" not in sys.modules:
+    _ensure_stubbed_dependency("pyghidra", types.ModuleType("pyghidra"))
+
+
+context_module = pytest.importorskip(
+    "pyghidra_mcp.context",
+    reason="pyghidra_mcp.context requires optional runtime dependencies",
+)
+server_module = pytest.importorskip(
+    "pyghidra_mcp.server",
+    reason="pyghidra_mcp.server requires optional runtime dependencies",
+)
+
+AnalysisIncompleteError = context_module.AnalysisIncompleteError
+ProgramInfo = context_module.ProgramInfo
+PyGhidraContext = context_module.PyGhidraContext
+
+
+class _DummyCtx:
+    def __init__(self, lifespan_context: object) -> None:
+        self.request_context = types.SimpleNamespace(
+            lifespan_context=lifespan_context
+        )
+
+
+def _make_incomplete_program_info(name: str = "binary") -> ProgramInfo:
+    return ProgramInfo(
+        name=name,
+        program=object(),
+        flat_api=None,
+        decompiler=object(),
+        metadata={},
+        ghidra_analysis_complete=False,
+        file_path=None,
+        load_time=None,
+        collection=None,
+        strings_collection=None,
+    )
+
+
+def test_get_program_info_raises_custom_error_when_analysis_incomplete():
+    context = PyGhidraContext.__new__(PyGhidraContext)
+    context.programs = {"binary": _make_incomplete_program_info()}
+
+    with pytest.raises(AnalysisIncompleteError) as exc_info:
+        context.get_program_info("binary")
+
+    error = exc_info.value
+    assert error.binary_name == "binary"
+    assert not error.ghidra_analysis_complete
+    assert not error.code_collection_ready
+    assert not error.strings_collection_ready
+    assert "Analysis incomplete" in str(error)
+    assert error.to_dict()["pending_components"]
+
+
+@pytest.mark.asyncio
+async def test_tool_error_handler_maps_incomplete_analysis_to_invalid_params():
+    class DummyContext:
+        def get_program_info(self, binary_name: str):
+            raise AnalysisIncompleteError(
+                binary_name=binary_name,
+                ghidra_analysis_complete=False,
+                code_collection_ready=False,
+                strings_collection_ready=False,
+            )
+
+    ctx = _DummyCtx(DummyContext())
+
+    with pytest.raises(server_module.McpError) as exc_info:
+        await server_module.decompile_function("binary", "function", ctx)
+
+    error_data = exc_info.value.error
+    assert error_data.code == server_module.INVALID_PARAMS
+    assert "analysis is incomplete" in error_data.message
+    assert error_data.data["binary_name"] == "binary"
+    assert error_data.data["pending_components"]
+    assert (
+        error_data.data["suggestion"].lower().startswith("wait")
+        or "wait" in error_data.data["suggestion"].lower()
+    )


### PR DESCRIPTION
## Summary
- add an AnalysisIncompleteError with structured metadata when analysis has not finished
- reuse a shared MCP error handler so tools surface INVALID_PARAMS with actionable messaging
- cover the new behavior with unit tests exercising get_program_info and the tool error mapping

## Testing
- pytest tests/unit

------
https://chatgpt.com/codex/tasks/task_e_68d056b152d48323a8f2500d4614053c