### PR TITLE
Use logger.warning in context warnings

### DIFF
--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -110,7 +110,7 @@ class PyGhidraContext:
         self.threaded = threaded
         self.max_workers = max_workers
         if not self.threaded:
-            logger.warn("--no-threaded flag forcing max_workers to 1")
+            logger.warning("--no-threaded flag forcing max_workers to 1")
             self.max_workers = 1
 
     def close(self, save: bool = True):
@@ -504,7 +504,7 @@ class PyGhidraContext:
                         self.set_analysis_option(program, k, v)
 
                 if self.no_symbols:
-                    logger.warn(
+                    logger.warning(
                         f"Disabling symbols for analysis! --no-symbols flag: {self.no_symbols}"
                     )
                     self.set_analysis_option(program, "PDB Universal", False)


### PR DESCRIPTION
## Summary
- replace the deprecated `logger.warn` calls in `PyGhidraContext` with `logger.warning`

## Testing
- python - <<'PY' ... (stubbed dependencies to instantiate `PyGhidraContext` with `threaded=False` and verify warning output)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d057476fe483238d1da340b5ab7aab