### PR TITLE
Avoid configuring root logger in context module

### DIFF
--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -22,9 +22,8 @@ if TYPE_CHECKING:
     from ghidra.program.flatapi import FlatProgramAPI
     from ghidra.program.model.listing import Program
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- stop the context module from configuring the root logger on import
- attach a `NullHandler` to the module logger to avoid "No handler found" warnings when logging isn’t configured

## Testing
- uv run pytest *(hangs on tests/integration/test_concurrent_streamable_client.py; interrupted after 60s without running tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d05b2778048323b21e096b5082795f