### PR TITLE
Lazy-load server module in package init

### DIFF
--- a/src/pyghidra_mcp/__init__.py
+++ b/src/pyghidra_mcp/__init__.py
@@ -1,4 +1,5 @@
-from . import server
+from typing import TYPE_CHECKING, Any
+
 from .context import ProgramInfo, PyGhidraContext
 from .tools import GhidraTools
 
@@ -8,7 +9,23 @@ __author__ = "clearbluejar"
 
 def main() -> None:
     """Main entry point for the package."""
-    server.main()
+    from . import server as server_module
+
+    server_module.main()
+
+
+def __getattr__(name: str) -> Any:
+    if name == "server":
+        from . import server as server_module
+
+        return server_module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+if TYPE_CHECKING:
+    from . import server as server_module
+
+    server = server_module
 
 
 # Optionally expose other important items at package level


### PR DESCRIPTION
## Summary
- defer importing the server module until `main()` executes to avoid initializing the server stack on package import
- add a module-level `__getattr__` shim so `pyghidra_mcp.server` remains lazily accessible via `__all__`

## Testing
- uv run pytest tests/unit

------
https://chatgpt.com/codex/tasks/task_e_68d05b38734483238784600652662443