### PR TITLE
Add health check endpoint for HTTP transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ Streamable HTTP enables streaming responses over JSON RPC via HTTP POST requests
 
 By default, the server listens on [127.0.0.1:8000/mcp](https://127.0.0.1/mcp) for client connections. To change any of this, set [FASTMCP_*](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/server/fastmcp/server.py#L78) environment variables. _The server must be running for clients to connect to it._
 
+Use `GET http://127.0.0.1:8000/health` to retrieve a JSON readiness report (project name, loaded binaries, and analysis status). The endpoint returns `200` when the project is ready and `503` if initialization fails.
+
 #### Python
 
 ```bash
@@ -352,6 +354,8 @@ docker run -p 8000:8000 ghcr.io/clearbluejar/pyghidra-mcp
 SSE transport enables server-to-client streaming with Server-Send Events for client-to-server and server-to-client communication. See the [spec](https://modelcontextprotocol.io/docs/concepts/transports#server-sent-events-sse) for more details.
 
 By default, the server listens on [127.0.0.1:8000/sse](https://127.0.0.1/sse) for client connections. To change any of this, set [FASTMCP_*](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/server/fastmcp/server.py#L78) environment variables. _The server must be running for clients to connect to it._
+
+The same `/health` endpoint is available over HTTP when running SSE mode for integration-friendly readiness checks.
 
 #### Python
 

--- a/tests/integration/test_sse_client.py
+++ b/tests/integration/test_sse_client.py
@@ -71,3 +71,17 @@ async def test_sse_client_smoke(sse_server):
             assert len(content.keys()) == len(DecompiledFunction.model_fields.keys())
             assert "entry" in content["code"]
             print(json.dumps(content, indent=2))
+
+
+@pytest.mark.asyncio
+async def test_sse_health_endpoint(sse_server):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{base_url}/health") as response:
+            assert response.status == 200
+            payload = await response.json()
+
+    assert payload["status"] == "ready"
+    assert payload["program_count"] >= 1
+    assert 0 <= payload["analyzed_programs"] <= payload["program_count"]
+    assert payload["project_name"]
+    assert payload["project_path"]

--- a/tests/integration/test_streamable_client.py
+++ b/tests/integration/test_streamable_client.py
@@ -72,3 +72,17 @@ async def test_streamable_client_smoke(streamable_server):
             assert len(content.keys()) == len(DecompiledFunction.model_fields.keys())
             assert "main(void)" in content["code"]
             print(json.dumps(content, indent=2))
+
+
+@pytest.mark.asyncio
+async def test_streamable_health_endpoint(streamable_server):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{base_url}/health") as response:
+            assert response.status == 200
+            payload = await response.json()
+
+    assert payload["status"] == "ready"
+    assert payload["program_count"] >= 1
+    assert 0 <= payload["analyzed_programs"] <= payload["program_count"]
+    assert payload["project_name"]
+    assert payload["project_path"]


### PR DESCRIPTION
## Summary
- expose a `/health` custom route that reports PyGhidra readiness details for HTTP-based transports
- capture initialization errors, safely close the PyGhidra context, and document the health endpoint for streamable HTTP and SSE
- extend the integration suite to verify the new endpoint for both streamable HTTP and SSE servers

## Testing
- uv run pytest tests/integration/test_streamable_client.py::test_streamable_health_endpoint *(fails: missing GHIDRA installation at /ghidra in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d05d50dbbc83238880a8cfa0fb76c8