### PR TITLE
Fix import binary message spacing

### DIFF
--- a/src/pyghidra_mcp/server.py
+++ b/src/pyghidra_mcp/server.py
@@ -379,8 +379,7 @@ def import_binary(binary_path: str, ctx: Context) -> str:
     def _import(pyghidra_context: PyGhidraContext) -> str:
         pyghidra_context.import_binary_backgrounded(binary_path)
         return (
-            f"Importing {binary_path} in the background."
-            "When ready, it will appear analyzed in binary list."
+            f"Importing {binary_path} in the background. When ready, it will appear analyzed in binary list."
         )
 
     return _run_tool(

--- a/tests/integration/test_import_binary.py
+++ b/tests/integration/test_import_binary.py
@@ -67,6 +67,7 @@ async def test_import_binary(test_binary_for_import, server_params_no_input):
 
             content = response.content[0].text
             assert test_binary_for_import in content
+            assert "background. When ready" in content
 
             ready = False
             for _ in range(240):


### PR DESCRIPTION
## Summary
- ensure the `import_binary` tool returns its two-sentence status message with natural spacing
- assert the integration test checks for the natural phrasing in the returned message

## Testing
- pytest tests/integration/test_import_binary.py *(fails: ModuleNotFoundError: No module named 'mcp')*


------
https://chatgpt.com/codex/tasks/task_e_68d0616001b88323940b2f31234d670d