### PR TITLE
Handle qualified names and addresses in decompile search

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Enable LLMs to perform actions, make deterministic computations, and interact wi
 
 #### Decompile Function
 
-- `decompile_function(binary_name: str, name: str)`: Decompile a function from a given binary.
+- `decompile_function(binary_name: str, name: str)`: Decompile a function from a given binary. The `name` argument can be either a fully qualified function name or an entry-point address (hex string).
 
 #### List Exports
 

--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -344,13 +344,15 @@ class PyGhidraContext:
                 try:
                     if i % 10 == 0:
                         logger.debug(f"Decompiling {i}/{len(functions)}")
-                    decompiled = tools.decompile_function(func.name)
+                    entry_point = str(func.getEntryPoint())
+                    decompiled = tools.decompile_function(entry_point)
                     decompiles.append(decompiled.code)
-                    ids.append(func.name)
+                    ids.append(entry_point)
                     metadatas.append(
                         {
-                            "function_name": func.name,
-                            "entry_point": str(func.getEntryPoint()),
+                            "function_name": func.getName(),
+                            "qualified_name": func.getName(True),
+                            "entry_point": entry_point,
                         }
                     )
                 except Exception as e:

--- a/tests/integration/test_concurrent_streamable_client.py
+++ b/tests/integration/test_concurrent_streamable_client.py
@@ -159,7 +159,7 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
         search_code_result = json.loads(client_responses[8].content[0].text)
         code_search_results = CodeSearchResults(**search_code_result)
         assert len(code_search_results.results) > 0
-        assert code_search_results.results[0].function_name == "function_one"
+        assert code_search_results.results[0].function_name.startswith("function_one")
 
         # Search strings
         search_string_result = json.loads(client_responses[9].content[0].text)

--- a/tests/integration/test_search_code.py
+++ b/tests/integration/test_search_code.py
@@ -1,12 +1,18 @@
 import os
+import subprocess
 import tempfile
+import textwrap
 
 import pytest
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 from pyghidra_mcp.context import PyGhidraContext
-from pyghidra_mcp.models import CodeSearchResults, DecompiledFunction
+from pyghidra_mcp.models import (
+    CodeSearchResults,
+    DecompiledFunction,
+    FunctionSearchResults,
+)
 
 
 @pytest.fixture(scope="module")
@@ -84,4 +90,163 @@ async def test_search_code(server_params):
             # 3. Assert the results
             assert len(search_results.results) > 0
             # The top result should be the function we searched for
-            assert search_results.results[0].function_name == "function_to_find"
+            top_result_name = search_results.results[0].function_name
+            assert top_result_name.startswith("function_to_find")
+            assert "@" in top_result_name
+
+
+@pytest.fixture(scope="module")
+def overloaded_cpp_binary():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".cc", delete=False) as f:
+        f.write(
+            textwrap.dedent(
+                """
+                #include <cstdio>
+
+                class OverloadExample {
+                public:
+                    __attribute__((noinline)) int compute(int value);
+                    __attribute__((noinline)) double compute(double value);
+                };
+
+                __attribute__((noinline)) int helper_int(int input) {
+                    return input * 2;
+                }
+
+                int OverloadExample::compute(int value) {
+                    return helper_int(value) + 1;
+                }
+
+                double OverloadExample::compute(double value) {
+                    return value * 2.0 + 0.5;
+                }
+
+                int call_compute_int() {
+                    OverloadExample example;
+                    return example.compute(10);
+                }
+
+                double call_compute_double() {
+                    OverloadExample example;
+                    return example.compute(10.0);
+                }
+
+                int main() {
+                    OverloadExample example;
+                    return example.compute(1) + static_cast<int>(example.compute(2.0));
+                }
+                """
+            )
+        )
+        cpp_file = f.name
+
+    bin_file = cpp_file.replace(".cc", "")
+
+    try:
+        subprocess.check_call(["g++", "-std=c++17", "-O0", "-g", "-o", bin_file, cpp_file])
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - compilation failure surface
+        raise RuntimeError(f"Failed to compile C++ test binary: {exc}") from exc
+
+    yield bin_file
+
+    os.unlink(cpp_file)
+    os.unlink(bin_file)
+
+
+@pytest.fixture(scope="module")
+def overloaded_server_params(overloaded_cpp_binary):
+    return StdioServerParameters(
+        command="python",
+        args=["-m", "pyghidra_mcp", overloaded_cpp_binary],
+        env={"GHIDRA_INSTALL_DIR": "/ghidra"},
+    )
+
+
+def _normalize_entry_point(value: str) -> str:
+    lowered = value.lower()
+    if lowered.startswith("0x"):
+        lowered = lowered[2:]
+    if ":" in lowered:
+        lowered = lowered.split(":")[-1]
+    return lowered
+
+
+@pytest.mark.asyncio
+async def test_search_code_with_overloads(overloaded_server_params):
+    async with stdio_client(overloaded_server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            binary_name = PyGhidraContext._gen_unique_bin_name(overloaded_server_params.args[-1])
+
+            function_response = await session.call_tool(
+                "search_functions_by_name",
+                {"binary_name": binary_name, "query": "compute"},
+            )
+
+            function_infos = FunctionSearchResults.model_validate_json(
+                function_response.content[0].text
+            )
+
+            overload_functions = [
+                func for func in function_infos.functions if "OverloadExample" in func.name
+            ]
+            assert len(overload_functions) >= 2
+
+            expected_entry_points = {
+                _normalize_entry_point(func.entry_point) for func in overload_functions[:2]
+            }
+
+            decompiled_results: list[DecompiledFunction] = []
+            qualified_names: set[str] = set()
+
+            for func in overload_functions[:2]:
+                entry_point_identifier = func.entry_point
+                decompile_response = await session.call_tool(
+                    "decompile_function",
+                    {"binary_name": binary_name, "name": entry_point_identifier},
+                )
+                decompiled = DecompiledFunction.model_validate_json(
+                    decompile_response.content[0].text
+                )
+                decompiled_results.append(decompiled)
+
+                qualified_name, _, address_part = decompiled.name.partition("@")
+                assert qualified_name
+                assert address_part
+                qualified_names.add(qualified_name)
+
+                qualified_response = await session.call_tool(
+                    "decompile_function",
+                    {"binary_name": binary_name, "name": qualified_name},
+                )
+                qualified_decompiled = DecompiledFunction.model_validate_json(
+                    qualified_response.content[0].text
+                )
+                assert qualified_decompiled.code == decompiled.code
+
+            assert len(qualified_names) >= 2
+
+            query_code = decompiled_results[0].code
+
+            search_response = await session.call_tool(
+                "search_code",
+                {"binary_name": binary_name, "query": query_code, "limit": 4},
+            )
+
+            search_results = CodeSearchResults.model_validate_json(search_response.content[0].text)
+
+            overload_matches = [
+                result
+                for result in search_results.results
+                if result.function_name.startswith("OverloadExample::compute")
+            ]
+            assert len(overload_matches) >= 2
+
+            result_entry_points = {
+                _normalize_entry_point(result.function_name.split("@")[-1])
+                for result in overload_matches
+                if "@" in result.function_name
+            }
+
+            assert expected_entry_points.issubset(result_entry_points)


### PR DESCRIPTION
## Summary
- allow `decompile_function` to resolve entry-point addresses and fully qualified names, emit qualified-name@address labels, and surface disambiguating metadata in code search results
- index chroma documents by unique entry-point IDs while storing both simple and fully qualified names for display
- extend integration coverage with an overloaded C++ fixture, update expectations, and document the expanded tool input

## Testing
- pytest tests/integration/test_search_code.py *(fails: ModuleNotFoundError: No module named 'mcp')*
- pytest tests/unit *(fails: ModuleNotFoundError / missing optional dependencies)*
- ruff check src/pyghidra_mcp/tools.py tests/integration/test_search_code.py

------
https://chatgpt.com/codex/tasks/task_e_68d0615a67508323bed1b37e897b60f5