### PR TITLE
Add analyze_now MCP tool for on-demand analysis

### DIFF
--- a/src/pyghidra_mcp/models.py
+++ b/src/pyghidra_mcp/models.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from mcp.types import ResourceContents
-
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -22,9 +21,17 @@ class FunctionResourceMetadata(BaseModel):
         ..., description="The kind of artifact (e.g. decompilation, disassembly, pcode)."
     )
     summary: str = Field(..., description="A short human readable summary of the artifact.")
-    resource_uri: str = Field(..., description="URI that can be used with the MCP resources API to fetch the artifact payload.")
+    resource_uri: str = Field(
+        ...,
+        description=(
+            "URI that can be used with the MCP resources API to fetch the artifact payload."
+        ),
+    )
     mime_type: str = Field(..., description="MIME type describing the artifact payload.")
-    signature: str | None = Field(None, description="Optional function signature information if available.")
+    signature: str | None = Field(
+        None,
+        description="Optional function signature information if available.",
+    )
     details: dict[str, Any] | None = Field(
         None, description="Additional structured metadata about the artifact."
     )
@@ -84,6 +91,27 @@ class ProgramInfos(BaseModel):
     """A container for a list of program information objects."""
 
     programs: list[ProgramInfo] = Field(..., description="A list of program information objects.")
+
+
+class AnalyzeNowResult(BaseModel):
+    """Status information returned by the analyze_now MCP tool."""
+
+    binary_name: str = Field(..., description="The name of the program that was analyzed.")
+    ghidra_analysis_complete: bool = Field(
+        ..., description="Indicates whether Ghidra has finished its analysis stage."
+    )
+    code_collection_ready: bool = Field(
+        ..., description="True if the code search collection has been rebuilt."
+    )
+    strings_collection_ready: bool = Field(
+        ..., description="True if the strings search collection has been rebuilt."
+    )
+    analysis_complete: bool = Field(
+        ..., description="Convenience flag signalling both Ghidra and Chroma are ready."
+    )
+    next_steps: str = Field(
+        ..., description="Guidance for the caller on what to do after invoking the tool."
+    )
 
 
 class ExportInfo(BaseModel):

--- a/tests/integration/test_analyze_now.py
+++ b/tests/integration/test_analyze_now.py
@@ -1,0 +1,57 @@
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from mcp import ClientSession
+from mcp.client.stdio import stdio_client
+
+from pyghidra_mcp.context import PyGhidraContext
+
+pytestmark = pytest.mark.skipif(
+    not Path("/ghidra").exists(), reason="Requires Ghidra installation"
+)
+
+
+async def _wait_for_program(session: ClientSession, binary_name: str, attempts: int = 120):
+    for _ in range(attempts):
+        response = await session.call_tool("list_project_binaries", {})
+        programs = json.loads(response.content[0].text)["programs"]
+        for program in programs:
+            if program["name"] == binary_name:
+                return program
+        await asyncio.sleep(1)
+    raise AssertionError(f"Binary {binary_name} did not appear in project list")
+
+
+@pytest.mark.asyncio
+async def test_analyze_now_unlocks_queries(test_binary, server_params_no_input):
+    async with stdio_client(server_params_no_input) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            binary_name = PyGhidraContext._gen_unique_bin_name(test_binary)
+
+            import_response = await session.call_tool(
+                "import_binary", {"binary_path": test_binary}
+            )
+            assert "Importing" in import_response.content[0].text
+
+            await _wait_for_program(session, binary_name)
+
+            analyze_response = await session.call_tool(
+                "analyze_now", {"binary_name": binary_name}
+            )
+            status = analyze_response.structuredContent
+            assert status["binary_name"] == binary_name
+            assert status["analysis_complete"] is True
+            assert status["ghidra_analysis_complete"] is True
+            assert status["code_collection_ready"] is True
+            assert status["strings_collection_ready"] is True
+            assert "ready" in status["next_steps"].lower()
+
+            search_response = await session.call_tool(
+                "search_functions_by_name", {"binary_name": binary_name, "query": "main"}
+            )
+            functions = json.loads(search_response.content[0].text)["functions"]
+            assert functions


### PR DESCRIPTION
## Summary
- add `PyGhidraContext.analyze_now` to force immediate analysis and rebuild per-program Chroma indexes
- expose a structured `analyze_now` MCP tool that surfaces analysis readiness metadata
- cover the new flow with an integration test that imports a binary, invokes `analyze_now`, and performs a follow-up query

## Testing
- `PYTHONPATH=src pytest tests/integration/test_analyze_now.py` *(skipped: requires `/ghidra`)*
- `ruff check src/pyghidra_mcp/context.py src/pyghidra_mcp/server.py src/pyghidra_mcp/models.py tests/integration/test_analyze_now.py`


------
https://chatgpt.com/codex/tasks/task_e_68d06535c4048323aa54fb41fdd57dfb