### PR TITLE
Add project_open tool and helper for switching projects

### DIFF
--- a/src/pyghidra_mcp/server.py
+++ b/src/pyghidra_mcp/server.py
@@ -619,6 +619,23 @@ def search_strings(
 
 
 @mcp.tool()
+def project_open(project_path: str, project_name: str, ctx: Context) -> str:
+    """Open or create a Ghidra project at the requested location."""
+
+    def _open(pyghidra_context: PyGhidraContext) -> str:
+        target_path = Path(project_path).expanduser()
+        resolved_path = target_path.resolve()
+        pyghidra_context.open_project(resolved_path, project_name)
+        return f"Project '{project_name}' opened at '{resolved_path}'."
+
+    return _run_tool(
+        ctx,
+        _open,
+        error_message="Error opening project",
+    )
+
+
+@mcp.tool()
 def import_binary(binary_path: str, ctx: Context) -> str:
     """Imports a binary from a designated path into the current Ghidra project.
 
@@ -653,7 +670,13 @@ def init_pyghidra_context(
     # init PyGhidraContext / import + analyze binaries
     logger.info("Server initializing...")
     try:
-        pyghidra_context = PyGhidraContext(project_name, project_directory)
+        project_root = Path(project_directory)
+        pyghidra_context = PyGhidraContext(
+            project_name,
+            project_root,
+            auto_open=False,
+        )
+        pyghidra_context.open_project(project_root, project_name)
         logger.info(f"Importing binaries: {project_directory}")
         pyghidra_context.import_binaries(bin_paths)
         logger.info(f"Analyzing project: {pyghidra_context.project}")

--- a/tests/integration/test_project_open.py
+++ b/tests/integration/test_project_open.py
@@ -1,0 +1,84 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+from mcp import ClientSession
+from mcp.client.stdio import stdio_client
+
+
+@pytest.mark.asyncio
+async def test_project_open_success(server_params):
+    """Opening a new project should return a success message and clear programs."""
+
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            initial_response = await session.call_tool("list_project_binaries", {})
+            initial_text = initial_response.content[0].text
+            assert initial_text is not None
+            initial_programs = json.loads(initial_text)["programs"]
+            assert initial_programs, "Expected initial project to contain binaries"
+
+            with tempfile.TemporaryDirectory() as new_root:
+                new_root_path = Path(new_root)
+                new_project_name = "project_open_success"
+
+                response = await session.call_tool(
+                    "project_open",
+                    {
+                        "project_path": str(new_root_path),
+                        "project_name": new_project_name,
+                    },
+                )
+
+                assert not response.isError
+                assert response.content
+                message = response.content[0].text
+                assert message is not None
+                assert new_project_name in message
+                assert str(new_root_path.resolve()) in message
+
+                updated_response = await session.call_tool("list_project_binaries", {})
+                updated_text = updated_response.content[0].text
+                assert updated_text is not None
+                updated_programs = json.loads(updated_text)["programs"]
+                assert updated_programs == []
+
+
+@pytest.mark.asyncio
+async def test_project_open_error(server_params_no_input):
+    """Invalid project locations should surface errors via MCP."""
+
+    async with stdio_client(server_params_no_input) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                bad_path = tmp.name
+
+            try:
+                response = await session.call_tool(
+                    "project_open",
+                    {
+                        "project_path": bad_path,
+                        "project_name": "bad_project",
+                    },
+                )
+
+                assert response.isError
+
+                structured = response.structuredContent or {}
+                error_info = structured.get("error") if isinstance(structured, dict) else None
+                if isinstance(error_info, dict):
+                    message = error_info.get("message")
+                    assert message is not None
+                    assert "Error opening project" in message
+                elif response.content:
+                    text = response.content[0].text
+                    if text is not None:
+                        assert "Error opening project" in text
+            finally:
+                os.unlink(bad_path)


### PR DESCRIPTION
## Summary
- expose a reusable `open_project` helper in `PyGhidraContext` and make the constructor optionally skip auto opening
- add a `project_open` MCP tool that uses the helper and update server startup to call it
- exercise the new tool in integration tests for success and failure cases

## Testing
- uv run pytest tests/integration/test_project_open.py *(fails: requires GHIDRA_INSTALL_DIR pointing to a real Ghidra install in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d06533eba883238302fd575a190f49