### PR TITLE
Add project locking helpers and concurrency tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ The `Makefile` provides several targets for testing and code quality:
 - `make check`: Run all quality checks.
 - `make dev`: Run the development workflow (format and check).
 
+### Project locking semantics
+
+`PyGhidraContext` coordinates all imports and program opens through an internal
+`_project_lock` helper that mirrors Ghidra's project/domain write locks. When
+adding new features that mutate the project (e.g., calling `importProgram`,
+`saveAs`, or `openProgram`), wrap the interaction with `with
+context._project_lock(...)` so concurrent tooling stays serialized. Unit tests
+exercise concurrent imports to ensure lock acquisition/release stays balanced
+and surfaces regressions quickly.
+
 ## API
 
 ### Tools


### PR DESCRIPTION
## Summary
- add a `_project_lock` context manager that negotiates project and domain write locks before mutating the Ghidra project
- wrap `import_binary` and `analyze_program` so imports and analyses acquire the new lock helper
- add unit stress tests covering locking behavior and document the locking contract for contributors

## Testing
- pytest tests/unit/test_context.py

------
https://chatgpt.com/codex/tasks/task_e_68d06535c2e883239eef9c7594e283ad