### PR TITLE
Add HTTP transport security controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,33 @@ By default, the Python package will run in `stdio` mode, so you will have to inc
 docker run -p 8000:8000 ghcr.io/clearbluejar/pyghidra-mcp
 ```
 
+#### HTTP security controls
+
+When exposing the Streamable HTTP or SSE transports, the server now provides built-in hardening options:
+
+- `--auth-token` / `PYGHIDRA_MCP_AUTH_TOKEN` – require clients to send an `Authorization: Bearer <token>` header. Requests without the token are rejected.
+- `--allowed-origin` / `PYGHIDRA_MCP_ALLOWED_ORIGINS` – supply one or more allowed `Origin` header values. Entries can be repeated or comma-separated in the environment variable. Local origins for `127.0.0.1` and `localhost` are added automatically.
+- `--http-host` / `PYGHIDRA_MCP_HOST` – choose the bind address for HTTP transports (defaults to `127.0.0.1`).
+- `--http-port` / `PYGHIDRA_MCP_PORT` – override the listening port (defaults to `8000`).
+
+Clients must include the same origin in requests whenever an `Origin` header is sent. For example:
+
+```bash
+uvx pyghidra-mcp \
+  --transport streamable-http \
+  --auth-token super-secret-token \
+  --allowed-origin "http://127.0.0.1:8000"
+```
+
+Then connect with headers similar to:
+
+```python
+headers = {
+    "Authorization": "Bearer super-secret-token",
+    "Origin": "http://127.0.0.1:8000",
+}
+```
+
 ### Server-sent events (SSE)
 
 > [!WARNING]

--- a/tests/integration/test_sse_client.py
+++ b/tests/integration/test_sse_client.py
@@ -3,6 +3,7 @@ import json
 import os
 import subprocess
 import time
+from urllib.parse import urlparse
 
 import aiohttp
 import pytest
@@ -13,6 +14,12 @@ from pyghidra_mcp.context import PyGhidraContext
 from pyghidra_mcp.models import DecompiledFunction
 
 base_url = os.getenv("MCP_BASE_URL", "http://127.0.0.1:8000")
+parsed_base = urlparse(base_url)
+HOST = parsed_base.hostname or "127.0.0.1"
+PORT = parsed_base.port or (443 if parsed_base.scheme == "https" else 80)
+ORIGIN = f"{parsed_base.scheme}://{HOST}:{PORT}"
+AUTH_TOKEN = "pyghidra-test-token"
+AUTH_HEADERS = {"Authorization": f"Bearer {AUTH_TOKEN}", "Origin": ORIGIN}
 
 print(f"MCP_BASE_URL: {base_url}")
 
@@ -22,7 +29,22 @@ def sse_server():
     binary_name = "/bin/ls"
     # Start the SSE server
     proc = subprocess.Popen(
-        ["python", "-m", "pyghidra_mcp", "--transport", "sse", binary_name],
+        [
+            "python",
+            "-m",
+            "pyghidra_mcp",
+            "--transport",
+            "sse",
+            "--http-host",
+            HOST,
+            "--http-port",
+            str(PORT),
+            "--auth-token",
+            AUTH_TOKEN,
+            "--allowed-origin",
+            ORIGIN,
+            binary_name,
+        ],
         env={**os.environ, "GHIDRA_INSTALL_DIR": "/ghidra"},
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
@@ -32,7 +54,7 @@ def sse_server():
         async with aiohttp.ClientSession() as session:
             for _ in range(timeout):  # Poll for 60 seconds
                 try:
-                    async with session.get(f"{base_url}/sse") as response:
+                    async with session.get(f"{base_url}/sse", headers=AUTH_HEADERS) as response:
                         if response.status == 200:
                             return
                 except aiohttp.ClientConnectorError:
@@ -51,7 +73,7 @@ def sse_server():
 
 @pytest.mark.asyncio
 async def test_sse_client_smoke(sse_server):
-    async with sse_client(f"{base_url}/sse") as (read_stream, write_stream):
+    async with sse_client(f"{base_url}/sse", headers=AUTH_HEADERS) as (read_stream, write_stream):
         async with ClientSession(read_stream, write_stream) as session:
             # Initializing session...
             await session.initialize()
@@ -85,3 +107,10 @@ async def test_sse_health_endpoint(sse_server):
     assert 0 <= payload["analyzed_programs"] <= payload["program_count"]
     assert payload["project_name"]
     assert payload["project_path"]
+
+
+@pytest.mark.asyncio
+async def test_sse_rejects_missing_auth(sse_server):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{base_url}/sse", headers={"Origin": ORIGIN}) as response:
+            assert response.status == 401


### PR DESCRIPTION
## Summary
- add CLI options for HTTP host, port, auth token and origin allowlists while wiring them into FastMCP security settings
- document the new HTTP security configuration and expand integration tests to exercise authenticated access
- refresh unit test stubs and coverage for the CLI security options and error handling helpers

## Testing
- make test-unit
- make test-integration

------
https://chatgpt.com/codex/tasks/task_e_68d06310ed1c8323b3e617837a288024